### PR TITLE
hash: segfault check key strcmp

### DIFF
--- a/libfiu/hash.c
+++ b/libfiu/hash.c
@@ -294,11 +294,13 @@ bool hash_del(struct hash *h, const char *key)
 		if (entry->in_use == NEVER) {
 			/* We got to a never used key, not found. */
 			return false;
-		} else if (entry->in_use == IN_USE &&
-				strcmp(key, entry->key) == 0) {
-			/* The key matches, remove it. */
-			found = true;
-			break;
+		} else if (entry->key) {
+				if (entry->in_use == IN_USE &&
+					strcmp(key, entry->key) == 0) {
+					/* The key matches, remove it. */
+					found = true;
+					break;
+				}
 		}
 
 		/* The key doesn't match this entry, continue with linear probing. */


### PR DESCRIPTION
entry->key return null ptr

[#0] 0x7fc62c706572 → __strcmp_sse2_unaligned()
[#1] 0x7fc62ce7b4e9 → hash_del(h=0x5609a8dd4160, key=0x7ffd6996cf40 "5609a8dc6990")
[#2] 0x7fc62ce7a2e6 → clear_ferror(stream=0x5609a8dc6990)
[#3] 0x7fc62ce7a2e6 → fclose(stream=0x5609a8dc6990)
[#4] 0x7fc62b5c7016 → internal_endent(stream=0x7ffd6996cf80)
[#5] 0x7fc62b5c7016 → _nss_files_getpwuid_r(uid=0x0, result=0x7fc62ca364e0 <resbuf.10695>, buffer=0x5609a8dd3640 "root", buflen=0x400, errnop=0x7fc62d4a56b8)
[#6] 0x7fc62c73c3dd → __getpwuid_r(uid=0x0, resbuf=0x7fc62ca364e0 <resbuf.10695>, buffer=<optimized out>, buflen=0x400, result=0x7ffd6996d060)
[#7] 0x7fc62c73bb40 → getpwuid(uid=0x0)
[#8] 0x5609a702fac1 → get_current_user_info.part()
[#9] 0x5609a7051475 → initialize_shell_variables()

